### PR TITLE
8 label route

### DIFF
--- a/apps/backend/src/label/dtos/create-label.dto.ts
+++ b/apps/backend/src/label/dtos/create-label.dto.ts
@@ -2,7 +2,7 @@ import { IsString, IsHexColor } from 'class-validator';
 
 export class CreateLabelDTO {
   @IsString()
-  title: string;
+  name: string;
 
   @IsString()
   description: string;

--- a/apps/backend/src/label/dtos/create-label.dto.ts
+++ b/apps/backend/src/label/dtos/create-label.dto.ts
@@ -1,0 +1,12 @@
+import { IsString, IsHexColor } from 'class-validator';
+
+export class CreateLabelDTO {
+  @IsString()
+  title: string;
+
+  @IsString()
+  description: string;
+
+  @IsHexColor()
+  color: string;
+}

--- a/apps/backend/src/label/label.controller.spec.ts
+++ b/apps/backend/src/label/label.controller.spec.ts
@@ -12,7 +12,7 @@ export const mockLabelService: Partial<LabelsService> = {
 };
 
 export const mockLabelDto: CreateLabelDTO = {
-  title: 'Test Label',
+  name: 'Test Label',
   description: 'Test Description',
   color: '#000000',
 };

--- a/apps/backend/src/label/label.controller.spec.ts
+++ b/apps/backend/src/label/label.controller.spec.ts
@@ -1,9 +1,29 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LabelsController } from './label.controller';
 import { LabelsService } from './label.service';
+import { CreateLabelDTO } from './dtos/create-label.dto';
+import { Label } from './types/label.entity';
 
 // Mock implementation for LabelsService
-const mockLabelService = {};
+export const mockLabelService: Partial<LabelsService> = {
+  createLabel: jest.fn((labelDto: CreateLabelDTO) =>
+    Promise.resolve(mockLabel),
+  ),
+};
+
+export const mockLabelDto: CreateLabelDTO = {
+  title: 'Test Label',
+  description: 'Test Description',
+  color: '#000000',
+};
+
+export const mockLabel: Label = {
+  id: 1,
+  name: 'Test Label',
+  description: 'Test Description',
+  color: '#000000',
+  tasks: [],
+};
 
 describe('LabelController', () => {
   let controller: LabelsController;
@@ -27,4 +47,14 @@ describe('LabelController', () => {
   });
 
   /* Test for create new label */
+  describe('POST /labels', () => {
+    it('should create a new label and return it', async () => {
+      jest.spyOn(mockLabelService, 'createLabel').mockResolvedValue(mockLabel);
+
+      const res = await controller.createLabel(mockLabelDto);
+
+      expect(res).toEqual(mockLabel);
+      expect(mockLabelService.createLabel).toHaveBeenCalledWith(mockLabelDto);
+    });
+  });
 });

--- a/apps/backend/src/label/label.controller.ts
+++ b/apps/backend/src/label/label.controller.ts
@@ -25,7 +25,7 @@ export class LabelsController {
    * @throws BadRequestException if label name is not provided
    * @throws BadRequestException if color is not provided or is not hexadecimal
    */
-  @Post()
+  @Post('/label')
   async createLabel(@Body() labelDto: CreateLabelDTO): Promise<Label> {
     return this.labelsService.createLabel(labelDto);
   }

--- a/apps/backend/src/label/label.controller.ts
+++ b/apps/backend/src/label/label.controller.ts
@@ -11,6 +11,7 @@ import {
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { LabelsService } from './label.service';
 import { Label } from './types/label.entity';
+import { CreateLabelDTO } from './dtos/create-label.dto';
 
 @ApiTags('labels')
 @Controller('labels')
@@ -24,4 +25,8 @@ export class LabelsController {
    * @throws BadRequestException if label name is not provided
    * @throws BadRequestException if color is not provided or is not hexadecimal
    */
+  @Post()
+  async createLabel(@Body() labelDto: CreateLabelDTO): Promise<Label> {
+    return this.labelsService.createLabel(labelDto);
+  }
 }

--- a/apps/backend/src/label/label.service.spec.ts
+++ b/apps/backend/src/label/label.service.spec.ts
@@ -13,25 +13,25 @@ describe('LabelService', () => {
   let service: LabelsService;
 
   const mockValidCreateLabelDTO = {
-    title: 'Label 1',
+    name: 'Label 1',
     description: 'Desc 1',
     color: '#000000',
   };
 
   const mockInvalidCreateLabelDTO1 = {
-    title: '',
+    name: '',
     description: 'Desc 1',
     color: '#000000',
   };
 
   const mockInvalidCreateLabelDTO2 = {
-    title: 'Label 2',
+    name: 'Label 2',
     description: 'Desc 2',
     color: '',
   };
 
   const mockInvalidCreateLabelDTO3 = {
-    title: 'Label 3',
+    name: 'Label 3',
     description: 'Desc 3',
     color: 'Hello',
   };

--- a/apps/backend/src/label/label.service.spec.ts
+++ b/apps/backend/src/label/label.service.spec.ts
@@ -4,11 +4,37 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Label } from './types/label.entity';
 import { LabelsService } from './label.service';
+import { mockLabel, mockLabelDto } from './label.controller.spec';
+import { BadRequestException } from '@nestjs/common';
 
 const mockLabelsRepository = mock<Repository<Label>>();
 
 describe('LabelService', () => {
   let service: LabelsService;
+
+  const mockValidCreateLabelDTO = {
+    title: 'Label 1',
+    description: 'Desc 1',
+    color: '#000000',
+  };
+
+  const mockInvalidCreateLabelDTO1 = {
+    title: '',
+    description: 'Desc 1',
+    color: '#000000',
+  };
+
+  const mockInvalidCreateLabelDTO2 = {
+    title: 'Label 2',
+    description: 'Desc 2',
+    color: '',
+  };
+
+  const mockInvalidCreateLabelDTO3 = {
+    title: 'Label 3',
+    description: 'Desc 3',
+    color: 'Hello',
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -28,5 +54,33 @@ describe('LabelService', () => {
     expect(service).toBeDefined();
   });
 
-  /* Tests for create new label */
+  describe('createLabel', () => {
+    it('should create a new label and return it', async () => {
+      // Mock the repository methods
+      mockLabelsRepository.create.mockReturnValue(mockLabel);
+      mockLabelsRepository.save.mockResolvedValue(mockLabel);
+
+      const label = await service.createLabel(mockValidCreateLabelDTO);
+
+      expect(label).toEqual(mockLabel);
+    });
+
+    it('should throw a BadRequestException when given null label name', async () => {
+      expect(async () => {
+        await service.createLabel(mockInvalidCreateLabelDTO1);
+      }).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw a BadRequestException when given null label color', async () => {
+      expect(async () => {
+        await service.createLabel(mockInvalidCreateLabelDTO2);
+      }).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw a BadRequestException when given invalid label color', async () => {
+      expect(async () => {
+        await service.createLabel(mockInvalidCreateLabelDTO3);
+      }).rejects.toThrow(BadRequestException);
+    });
+  });
 });

--- a/apps/backend/src/label/label.service.spec.ts
+++ b/apps/backend/src/label/label.service.spec.ts
@@ -37,6 +37,11 @@ describe('LabelService', () => {
   };
 
   beforeEach(async () => {
+    mockLabelsRepository.create.mockReset();
+    mockLabelsRepository.save.mockReset();
+    mockLabelsRepository.findOneBy.mockReset();
+    mockLabelsRepository.find.mockReset();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         LabelsService,
@@ -68,19 +73,25 @@ describe('LabelService', () => {
     it('should throw a BadRequestException when given null label name', async () => {
       expect(async () => {
         await service.createLabel(mockInvalidCreateLabelDTO1);
-      }).rejects.toThrow(BadRequestException);
+      }).rejects.toThrow(
+        new BadRequestException("The 'name' field cannot be null"),
+      );
     });
 
     it('should throw a BadRequestException when given null label color', async () => {
       expect(async () => {
         await service.createLabel(mockInvalidCreateLabelDTO2);
-      }).rejects.toThrow(BadRequestException);
+      }).rejects.toThrow(
+        new BadRequestException("The 'color' field cannot be null"),
+      );
     });
 
     it('should throw a BadRequestException when given invalid label color', async () => {
       expect(async () => {
         await service.createLabel(mockInvalidCreateLabelDTO3);
-      }).rejects.toThrow(BadRequestException);
+      }).rejects.toThrow(
+        new BadRequestException("The 'color' field must be a valid hex color"),
+      );
     });
   });
 });

--- a/apps/backend/src/label/label.service.ts
+++ b/apps/backend/src/label/label.service.ts
@@ -1,7 +1,9 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Label } from './types/label.entity';
+import { CreateLabelDTO } from './dtos/create-label.dto';
+import { isHexColor } from 'class-validator';
 
 @Injectable()
 export class LabelsService {
@@ -11,4 +13,22 @@ export class LabelsService {
   ) {}
 
   // Creates a new label
+  async createLabel(labelDto: CreateLabelDTO): Promise<Label> {
+    if (!labelDto.title) {
+      throw new BadRequestException("The 'title' field cannot be null");
+    }
+
+    if (!labelDto.color) {
+      throw new BadRequestException("The 'color' field cannot be null");
+    }
+
+    if (!isHexColor(labelDto.color)) {
+      throw new BadRequestException(
+        "The 'color' field must be a valid hex color",
+      );
+    }
+
+    const newLabel = this.labelRepository.create(labelDto);
+    return this.labelRepository.save(newLabel);
+  }
 }

--- a/apps/backend/src/label/label.service.ts
+++ b/apps/backend/src/label/label.service.ts
@@ -14,8 +14,8 @@ export class LabelsService {
 
   // Creates a new label
   async createLabel(labelDto: CreateLabelDTO): Promise<Label> {
-    if (!labelDto.title) {
-      throw new BadRequestException("The 'title' field cannot be null");
+    if (!labelDto.name) {
+      throw new BadRequestException("The 'name' field cannot be null");
     }
 
     if (!labelDto.color) {


### PR DESCRIPTION
### ℹ️ Issue

Closes #8

### 📝 Description

1. Added controller endpoint for creating and adding labels with a name, description, and hex color field, with supporting service functionality

### ✔️ Verification

Used Jest testing and postman

SENDING IN VALID REQUEST (valid name + color)
<img width="1215" height="832" alt="Screenshot 2025-08-17 at 5 24 33 PM" src="https://github.com/user-attachments/assets/20843bd8-e041-4383-88ab-83cde74acaf7" />

SENDING INVALID REQUEST (null name)
<img width="1208" height="810" alt="Screenshot 2025-08-17 at 5 24 45 PM" src="https://github.com/user-attachments/assets/6cec17ce-8b28-4fc5-9179-42c6794c5067" />

SENDING INVALID REQUEST (non-hex color)
<img width="1216" height="814" alt="Screenshot 2025-08-17 at 5 25 00 PM" src="https://github.com/user-attachments/assets/fc913d27-ef9a-4594-80bf-c6bba7b641b3" />

Provide screenshots of any new components, styling changes, or pages. 

### 🏕️ (Optional) Future Work / Notes

# IMPORTANT: I noticed that the ticket asked for a "title" field, however the label entity had a "name" field. The DTO takes in a "name" field to match the entity, but can change to "title" if needed! 
