### PR TITLE
add_labels endpoint implemented/tested

### DIFF
--- a/apps/backend/src/task/dtos/update-labels.dto.ts
+++ b/apps/backend/src/task/dtos/update-labels.dto.ts
@@ -1,0 +1,11 @@
+import { IsArray, IsNumber, ArrayNotEmpty } from 'class-validator';
+
+export class UpdateLabelsDTO {
+  @IsNumber()
+  taskId: number;
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsNumber({}, { each: true })
+  labelIds: number[];
+}

--- a/apps/backend/src/task/task.controller.spec.ts
+++ b/apps/backend/src/task/task.controller.spec.ts
@@ -4,7 +4,6 @@ import { TasksController } from './task.controller';
 import { Task } from './types/task.entity';
 import { TaskCategory } from './types/category';
 import { BadRequestException } from '@nestjs/common';
-import { Label } from '../label/types/label.entity';
 
 const mockCreateTaskDTO = {
   title: 'Task 1',
@@ -60,6 +59,7 @@ export const mockTaskService: Partial<TasksService> = {
   ),
   getAllTasks: jest.fn(() => Promise.resolve(mockTasks)),
   createTask: jest.fn(),
+  addTaskLabels: jest.fn(),
   removeTaskLabels: jest.fn(),
   updateTask: jest.fn(),
 };
@@ -156,85 +156,49 @@ describe('TasksController', () => {
   });
 
   /* Tests for add labels to task by id */
+  describe('POST /tasks/add_labels', () => {
+    it('should call service with correct parameters and return the result', async () => {
+      const updateLabelsDto = {
+        // actual schema doesn't matter here
+        taskId: 1,
+        labelIds: [10, 20],
+      };
+      const mockServiceResponse = { ...mockTask, labels: [] };
+
+      jest
+        .spyOn(mockTaskService, 'addTaskLabels')
+        .mockResolvedValue(mockServiceResponse);
+
+      const result = await controller.addTaskLabels(updateLabelsDto);
+
+      expect(mockTaskService.addTaskLabels).toHaveBeenCalledWith(
+        updateLabelsDto.taskId,
+        updateLabelsDto.labelIds,
+      );
+      expect(result).toBe(mockServiceResponse);
+    });
+  });
 
   /* Tests for remove labels from task by id */
-  describe('POST /tasks/:taskId/remove_labels', () => {
-    it('should successfully remove labels from task', async () => {
-      const taskId = 1;
-      const labelIds = [10, 20];
-      const mockTaskAfterRemoval: Task = {
-        id: taskId,
-        title: 'Test Task',
-        description: null,
-        dateCreated: new Date('2024-01-01'),
-        dueDate: new Date('2024-12-31'),
-        category: TaskCategory.DRAFT,
-        labels: [{ id: 30, name: 'Label 3' } as Label],
+  describe('POST /tasks/remove_labels', () => {
+    it('should call service with correct parameters and return the result', async () => {
+      const updateLabelsDto = {
+        taskId: 1,
+        labelIds: [10, 20],
       };
-      // mock service method output
-      jest
-        .spyOn(mockTaskService, 'removeTaskLabels')
-        .mockResolvedValue(mockTaskAfterRemoval);
-
-      const result = await controller.removeTaskLabels(taskId, labelIds);
-
-      expect(result).toEqual(mockTaskAfterRemoval);
-      expect(mockTaskService.removeTaskLabels).toHaveBeenCalledWith(
-        taskId,
-        labelIds,
-      );
-    });
-
-    it('should throw BadRequestException when taskId does not exist', async () => {
-      const taskId = null;
-      const labelIds = [10, 20];
-
-      await expect(
-        controller.removeTaskLabels(taskId, labelIds),
-      ).rejects.toThrow(
-        new BadRequestException("taskId with ID null doesn't exist"),
-      );
-
-      expect(mockTaskService.removeTaskLabels).not.toHaveBeenCalled();
-    });
-
-    it('should throw BadRequestException when labelIds do not exist', async () => {
-      const taskId = 1;
-      const labelIds = [10, null, 20];
-
-      await expect(
-        controller.removeTaskLabels(taskId, labelIds),
-      ).rejects.toThrow(
-        new BadRequestException('at least 1 label id does not exist'),
-      );
-
-      expect(mockTaskService.removeTaskLabels).not.toHaveBeenCalled();
-    });
-
-    it('should call service when all validations pass', async () => {
-      const taskId = 1;
-      const labelIds = [10, 20, 30];
-      const mockTaskAfterRemoval: Task = {
-        id: taskId,
-        title: 'Test Task',
-        description: null,
-        dateCreated: new Date('2024-01-01'),
-        dueDate: new Date('2024-12-31'),
-        category: TaskCategory.DRAFT,
-        labels: [],
-      };
+      const mockServiceResponse = { ...mockTask, labels: [] };
 
       jest
         .spyOn(mockTaskService, 'removeTaskLabels')
-        .mockResolvedValue(mockTaskAfterRemoval);
+        .mockResolvedValue(mockServiceResponse);
 
-      const result = await controller.removeTaskLabels(taskId, labelIds);
+      const result = await controller.removeTaskLabels(updateLabelsDto);
 
       expect(mockTaskService.removeTaskLabels).toHaveBeenCalledWith(
-        taskId,
-        labelIds,
+        updateLabelsDto.taskId,
+        updateLabelsDto.labelIds,
       );
-      expect(result).toEqual(mockTaskAfterRemoval);
+      expect(result).toBe(mockServiceResponse);
     });
   });
 });

--- a/apps/backend/src/task/task.controller.ts
+++ b/apps/backend/src/task/task.controller.ts
@@ -10,12 +10,14 @@ import {
   Put,
   BadRequestException,
   ParseIntPipe,
+  ValidationPipe,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { TasksService } from './task.service';
 import { Task } from './types/task.entity';
 import { CreateTaskDTO } from './dtos/create-task.dto';
 import { UpdateTaskDTO } from './dtos/update-task.dto';
+import { UpdateLabelsDTO } from './dtos/update-labels.dto';
 import { TaskCategory } from './types/category';
 import { Label } from '../label/types/label.entity';
 
@@ -96,36 +98,32 @@ export class TasksController {
   }
 
   /** Add labels to task by its ID
-   * @param id The ID of the task to add labels to.
-   * @param labels The labels to add to the task.
+   * @param updateLabelsDto The DTO containing taskId and labelIds to add.
    * @returns The updated task.
    * @throws BadRequestException if the task with the given ID does not exist.
    * @throws BadRequestException if the labels are invalid.
    */
+  @Post('/add_labels')
+  async addTaskLabels(@Body(ValidationPipe) updateLabelsDto: UpdateLabelsDTO) {
+    return await this.tasksService.addTaskLabels(
+      updateLabelsDto.taskId,
+      updateLabelsDto.labelIds,
+    );
+  }
 
   /** Remove labels from task by its ID
-   * @param taskId The ID of the task to remove labels from.
-   * @param labelIds The labels to remove from the task.
+   * @param updateLabelsDto The DTO containing taskId and labelIds to remove.
    * @returns The updated task.
    * @throws BadRequestException if the task with the given ID does not exist.
    * @throws BadRequestException if the labels are invalid.
    */
-  @Post('/:taskId/remove_labels')
+  @Post('/remove_labels')
   async removeTaskLabels(
-    @Param('taskId', ParseIntPipe) taskId: number,
-    @Body('labelIds') labelIds: number[],
+    @Body(ValidationPipe) updateLabelsDto: UpdateLabelsDTO,
   ) {
-    if (!taskId || typeof taskId !== 'number') {
-      throw new BadRequestException(`taskId with ID ${taskId} doesn't exist`);
-    }
-    // checking that all the labels exist
-    for (const id of labelIds) {
-      if (!id || typeof id !== 'number') {
-        throw new BadRequestException('at least 1 label id does not exist');
-      }
-    }
-
-    // type validation done, now business logic:
-    return await this.tasksService.removeTaskLabels(taskId, labelIds);
+    return await this.tasksService.removeTaskLabels(
+      updateLabelsDto.taskId,
+      updateLabelsDto.labelIds,
+    );
   }
 }

--- a/apps/backend/src/task/task.module.ts
+++ b/apps/backend/src/task/task.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { TasksController } from './task.controller';
 import { TasksService } from './task.service';
 import { Task } from './types/task.entity';
+import { Label } from '../label/types/label.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Task])],
+  imports: [TypeOrmModule.forFeature([Task, Label])],
   controllers: [TasksController],
   providers: [TasksService],
   exports: [TasksService],

--- a/apps/backend/src/task/task.service.spec.ts
+++ b/apps/backend/src/task/task.service.spec.ts
@@ -196,12 +196,6 @@ describe('TasksService', () => {
   });
   /* Tests for add labels to task by id */
   describe('addTaskLabels', () => {
-    beforeEach(async () => {
-      mockTaskRepository.findOne.mockReset();
-      mockTaskRepository.save.mockReset();
-      mockLabelRepository.find.mockReset();
-    });
-
     it('should successfully add labels to a task', async () => {
       const taskId = 1;
       const labelIdsToAdd = [10, 20];
@@ -465,9 +459,7 @@ describe('TasksService', () => {
       await expect(
         service.removeTaskLabels(nonExistentTaskId, labelIdsToRemove),
       ).rejects.toThrow(
-        new BadRequestException(
-          'taskId with ID 999 does not exist in database',
-        ),
+        new BadRequestException('Task with ID 999 does not exist in database'),
       );
 
       expect(mockTaskRepository.findOne).toHaveBeenCalledWith({

--- a/apps/backend/src/task/task.service.spec.ts
+++ b/apps/backend/src/task/task.service.spec.ts
@@ -11,6 +11,7 @@ import { BadRequestException } from '@nestjs/common';
 import { Label } from '../label/types/label.entity';
 
 const mockTaskRepository = mock<Repository<Task>>();
+const mockLabelRepository = mock<Repository<Label>>();
 
 describe('TasksService', () => {
   let service: TasksService;
@@ -59,9 +60,11 @@ describe('TasksService', () => {
 
   beforeEach(async () => {
     mockTaskRepository.find.mockReset();
+    mockTaskRepository.findOne.mockReset();
     mockTaskRepository.findOneBy.mockReset();
     mockTaskRepository.save.mockReset();
     mockTaskRepository.create.mockReset();
+    mockLabelRepository.find.mockReset();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -69,6 +72,10 @@ describe('TasksService', () => {
         {
           provide: getRepositoryToken(Task),
           useValue: mockTaskRepository,
+        },
+        {
+          provide: getRepositoryToken(Label),
+          useValue: mockLabelRepository,
         },
       ],
     }).compile();
@@ -188,27 +195,185 @@ describe('TasksService', () => {
     expect(result).toEqual(mockUpdatedTask);
   });
   /* Tests for add labels to task by id */
+  describe('addTaskLabels', () => {
+    beforeEach(async () => {
+      mockTaskRepository.findOne.mockReset();
+      mockTaskRepository.save.mockReset();
+      mockLabelRepository.find.mockReset();
+    });
+
+    it('should successfully add labels to a task', async () => {
+      const taskId = 1;
+      const labelIdsToAdd = [10, 20];
+
+      const mockTask: Task = {
+        id: taskId,
+        title: 'Test Task',
+        description: null,
+        dateCreated: new Date('2024-01-01'),
+        dueDate: new Date('2024-12-31'),
+        category: TaskCategory.DRAFT,
+        labels: [{ id: 30, name: 'Label 3' } as Label],
+      };
+
+      const labelsToAdd: Label[] = [
+        { id: 10, name: 'Label 1' } as Label,
+        { id: 20, name: 'Label 2' } as Label,
+      ];
+
+      const expectedTaskAfterAddition: Task = {
+        ...mockTask,
+        labels: [
+          { id: 30, name: 'Label 3' } as Label,
+          { id: 10, name: 'Label 1' } as Label,
+          { id: 20, name: 'Label 2' } as Label,
+        ],
+      };
+
+      mockTaskRepository.findOne.mockResolvedValue(mockTask);
+      mockLabelRepository.find.mockResolvedValue(labelsToAdd);
+      mockTaskRepository.save.mockResolvedValue(expectedTaskAfterAddition);
+
+      const result = await service.addTaskLabels(taskId, labelIdsToAdd);
+
+      expect(mockTaskRepository.findOne).toHaveBeenCalledWith({
+        where: { id: taskId },
+        relations: ['labels'],
+      });
+
+      expect(mockLabelRepository.find).toHaveBeenCalledWith({
+        where: { id: expect.anything() },
+      });
+
+      expect(result).toEqual(expectedTaskAfterAddition);
+      expect(result.labels).toHaveLength(3);
+    });
+
+    it('should not add duplicate labels', async () => {
+      const taskId = 1;
+      const labelIdsToAdd = [10, 20]; // 10 already exists
+
+      const mockTask: Task = {
+        id: taskId,
+        title: 'Test Task',
+        description: null,
+        dateCreated: new Date('2024-01-01'),
+        dueDate: new Date('2024-12-31'),
+        category: TaskCategory.DRAFT,
+        labels: [{ id: 10, name: 'Label 1' } as Label], // Label 10 already exists
+      };
+
+      const labelsToAdd: Label[] = [
+        { id: 10, name: 'Label 1' } as Label,
+        { id: 20, name: 'Label 2' } as Label,
+      ];
+
+      const expectedTaskAfterAddition: Task = {
+        ...mockTask,
+        labels: [
+          { id: 10, name: 'Label 1' } as Label,
+          { id: 20, name: 'Label 2' } as Label, // Only label 20 should be added
+        ],
+      };
+
+      mockTaskRepository.findOne.mockResolvedValue(mockTask);
+      mockLabelRepository.find.mockResolvedValue(labelsToAdd);
+      mockTaskRepository.save.mockResolvedValue(expectedTaskAfterAddition);
+
+      const result = await service.addTaskLabels(taskId, labelIdsToAdd);
+
+      expect(result.labels).toHaveLength(2);
+    });
+
+    it('should throw BadRequestException when task does not exist', async () => {
+      const nonExistentTaskId = 999;
+      const labelIdsToAdd = [10, 20];
+
+      mockTaskRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.addTaskLabels(nonExistentTaskId, labelIdsToAdd),
+      ).rejects.toThrow(
+        new BadRequestException(
+          `Task with ID ${nonExistentTaskId} does not exist in database`,
+        ),
+      );
+
+      expect(mockTaskRepository.findOne).toHaveBeenCalledWith({
+        where: { id: nonExistentTaskId },
+        relations: ['labels'],
+      });
+
+      expect(mockLabelRepository.find).not.toHaveBeenCalled();
+      expect(mockTaskRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when one label does not exist', async () => {
+      const taskId = 1;
+      const labelIdsToAdd = [10, 999]; // 999 doesn't exist
+
+      const mockTask: Task = {
+        id: taskId,
+        title: 'Test Task',
+        description: null,
+        dateCreated: new Date('2024-01-01'),
+        dueDate: new Date('2024-12-31'),
+        category: TaskCategory.DRAFT,
+        labels: [],
+      };
+
+      const existingLabels: Label[] = [{ id: 10, name: 'Label 1' } as Label];
+
+      mockTaskRepository.findOne.mockResolvedValue(mockTask);
+      mockLabelRepository.find.mockResolvedValue(existingLabels);
+
+      await expect(
+        service.addTaskLabels(taskId, labelIdsToAdd),
+      ).rejects.toThrow(
+        new BadRequestException('Label with ID 999 does not exist in database'),
+      );
+
+      expect(mockTaskRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when multiple labels do not exist', async () => {
+      const taskId = 1;
+      const labelIdsToAdd = [10, 998, 999]; // 998 and 999 don't exist
+
+      const mockTask: Task = {
+        id: taskId,
+        title: 'Test Task',
+        description: null,
+        dateCreated: new Date('2024-01-01'),
+        dueDate: new Date('2024-12-31'),
+        category: TaskCategory.DRAFT,
+        labels: [],
+      };
+
+      const existingLabels: Label[] = [{ id: 10, name: 'Label 1' } as Label];
+
+      mockTaskRepository.findOne.mockResolvedValue(mockTask);
+      mockLabelRepository.find.mockResolvedValue(existingLabels);
+
+      await expect(
+        service.addTaskLabels(taskId, labelIdsToAdd),
+      ).rejects.toThrow(
+        new BadRequestException(
+          'Labels with IDs 998, 999 do not exist in database',
+        ),
+      );
+
+      expect(mockTaskRepository.save).not.toHaveBeenCalled();
+    });
+  });
 
   /* Tests for remove labels from task by id */
 
   describe('removeTaskLabels', () => {
-    let service: TasksService;
     // setup/reset mock service
     beforeEach(async () => {
       mockTaskRepository.findOne.mockReset();
       mockTaskRepository.save.mockReset();
-
-      const module: TestingModule = await Test.createTestingModule({
-        providers: [
-          TasksService,
-          {
-            provide: getRepositoryToken(Task),
-            useValue: mockTaskRepository,
-          },
-        ],
-      }).compile();
-
-      service = module.get<TasksService>(TasksService);
     });
 
     it('should successfully remove 2 valid labels from task', async () => {
@@ -280,7 +445,7 @@ describe('TasksService', () => {
 
       await expect(
         service.removeTaskLabels(taskId, labelIdsToRemove),
-      ).rejects.toThrow('Label IDs 99 are not assigned to this task');
+      ).rejects.toThrow('Label ID 99 is not assigned to this task');
 
       expect(mockTaskRepository.findOne).toHaveBeenCalledWith({
         where: { id: taskId },
@@ -300,7 +465,9 @@ describe('TasksService', () => {
       await expect(
         service.removeTaskLabels(nonExistentTaskId, labelIdsToRemove),
       ).rejects.toThrow(
-        new BadRequestException('taskId does not exist in database'),
+        new BadRequestException(
+          'taskId with ID 999 does not exist in database',
+        ),
       );
 
       expect(mockTaskRepository.findOne).toHaveBeenCalledWith({

--- a/apps/backend/src/task/task.service.ts
+++ b/apps/backend/src/task/task.service.ts
@@ -123,7 +123,7 @@ export class TasksService {
     });
     if (!task) {
       throw new BadRequestException(
-        `taskId with ID ${taskId} does not exist in database`,
+        `Task with ID ${taskId} does not exist in database`,
       );
     }
     // validate that the labelIds are associated with the given task

--- a/apps/backend/src/task/task.service.ts
+++ b/apps/backend/src/task/task.service.ts
@@ -1,16 +1,19 @@
 import { Task } from './types/task.entity';
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, In } from 'typeorm';
 import { CreateTaskDTO } from './dtos/create-task.dto';
 import { TaskCategory } from './types/category';
 import { UpdateTaskDTO } from './dtos/update-task.dto';
+import { Label } from '../label/types/label.entity';
 
 @Injectable()
 export class TasksService {
   constructor(
     @InjectRepository(Task)
     private readonly taskRepository: Repository<Task>,
+    @InjectRepository(Label)
+    private readonly labelRepository: Repository<Label>,
   ) {}
 
   // Saves a new task to the 'tasks' table using the given CreateTaskDTO
@@ -63,6 +66,54 @@ export class TasksService {
   }
 
   /** Add labels to task by its ID. */
+  async addTaskLabels(taskId: number, labelIds: number[]) {
+    // check that task actually exists
+    const task = await this.taskRepository.findOne({
+      where: { id: taskId },
+      relations: ['labels'],
+    });
+
+    // if doesn't, throw exception
+    if (!task) {
+      throw new BadRequestException(
+        `Task with ID ${taskId} does not exist in database`,
+      );
+    }
+
+    // checking that all labels are valid
+    const labelsToAdd = await this.labelRepository.find({
+      where: { id: In(labelIds) },
+    });
+
+    // Check if all requested label IDs exist
+    const foundLabelIds = labelsToAdd.map((label) => label.id);
+    const missingLabelIds = labelIds.filter(
+      (id) => !foundLabelIds.includes(id),
+    );
+
+    if (missingLabelIds.length === 1) {
+      throw new BadRequestException(
+        `Label with ID ${missingLabelIds[0]} does not exist in database`,
+      );
+    } else if (missingLabelIds.length > 1) {
+      throw new BadRequestException(
+        `Labels with IDs ${missingLabelIds.join(
+          ', ',
+        )} do not exist in database`,
+      );
+    }
+
+    // avoid duplicate labels
+    const currentLabelIds = task.labels.map((label) => label.id);
+    const newLabels = labelsToAdd.filter(
+      (label) => !currentLabelIds.includes(label.id),
+    );
+
+    // Add new labels to the task
+    task.labels = [...task.labels, ...newLabels];
+
+    return this.taskRepository.save(task);
+  }
 
   /** Remove labels from task by its ID. */
   async removeTaskLabels(taskId: number, labelIds: number[]) {


### PR DESCRIPTION
### ℹ️ Issue

Closes <issue>

### 📝 Description

Added add_label endpoint with DTO Validation to link labels to a given task. Modified remove_label endpoint to reflect the same DTO as well.

### ✔️ Verification

Did unit tests of the service layer and controller layer, business logic for if task/label ids actually exist

Relied on ValidationPipe for type checking, so used Postman to check:

passing in string for taskId: 400
<img width="1299" height="876" alt="Screenshot 2025-08-21 at 8 16 35 PM" src="https://github.com/user-attachments/assets/7c29e9b3-dbf6-4344-b984-fd02a1303255" />
passing in empty label list: 400
<img width="1299" height="876" alt="Screenshot 2025-08-21 at 8 17 00 PM" src="https://github.com/user-attachments/assets/210089fd-9f1f-414f-bbbd-8ffda62ace0f" />
passing in invalid string item in labelid list:
<img width="1299" height="876" alt="Screenshot 2025-08-21 at 8 17 10 PM" src="https://github.com/user-attachments/assets/f81d74d2-6252-4839-a9fa-dcd3698dad5a" />
passing in non-existent task id
<img width="1299" height="876" alt="Screenshot 2025-08-21 at 8 17 30 PM" src="https://github.com/user-attachments/assets/5bedaea5-4e35-49f8-9a61-14a16935f165" />
:

passing in non-existent label id:
<img width="1299" height="876" alt="Screenshot 2025-08-21 at 8 17 39 PM" src="https://github.com/user-attachments/assets/6568efdd-b6f9-44fa-bb0b-92d4575dbaa2" />

passing in success to add labels
<img width="1299" height="876" alt="Screenshot 2025-08-21 at 8 25 29 PM" src="https://github.com/user-attachments/assets/d9db4e4f-5dcc-4111-b8d8-9987354caa62" />

