### PR TITLE
23 header

### DIFF
--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -16,7 +16,7 @@ const Header: React.FC<HeaderProps> = ({ firstName, lastName, title }) => {
   const initials = getInitials(firstName, lastName);
   const fullName = `${firstName} ${lastName}`;
   // if title is provided, use it, otherwise use full name
-  const displayName = title ? title : fullName;
+  const displayTitle = title ? title : fullName;
   return (
     <div className="w-full">
       <div className="flex items-center gap-4 px-6 py-4">
@@ -33,7 +33,7 @@ const Header: React.FC<HeaderProps> = ({ firstName, lastName, title }) => {
           {initials}
         </Avatar>
         {/* Display Name */}
-        <h1 className="text-2xl font-medium text-gray-900">{displayName}</h1>
+        <h1 className="text-2xl font-medium text-gray-900">{displayTitle}</h1>
       </div>
 
       {/* Separator Line */}

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -1,33 +1,36 @@
 import React from 'react';
-import Avatar from '@mui/material/Avatar';
 
 interface CustomNameHeaderProps {
-  initials?: string;
-  name?: string;
+  firstName: string;
+  lastName: string;
 }
 
+// helper function to get initials from first and last name
+const getInitials = (firstName: string, lastName: string): string => {
+  return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+};
+
 const CustomNameHeader: React.FC<CustomNameHeaderProps> = ({
-  initials = 'CN',
-  name = 'Custom Name',
+  firstName,
+  lastName,
 }) => {
+  const initials = getInitials(firstName, lastName);
+  const fullName = `${firstName} ${lastName}`;
+
   return (
     <div className="w-full">
+      {/* Header Section - no background, inherits from parent */}
       <div className="flex items-center gap-4 px-6 py-4">
-        {/* MUI Avatar with Initials */}
-        <Avatar
-          sx={{
-            width: 40,
-            height: 40,
-            backgroundColor: '#D0D0D0',
-            fontSize: '0.875rem',
-            fontWeight: 500,
-          }}
+        {/* Custom Avatar with Initials */}
+        <div
+          className="w-10 h-10 rounded-full flex items-center justify-center"
+          style={{ backgroundColor: '#D0D0D0' }}
         >
-          {initials}
-        </Avatar>
+          <span className="text-white text-sm font-medium">{initials}</span>
+        </div>
 
-        {/* Name */}
-        <h1 className="text-2xl font-medium text-gray-900">{name}</h1>
+        {/* Custom Name */}
+        <h1 className="text-2xl font-medium text-gray-900">{fullName}</h1>
       </div>
 
       {/* Separator Line */}

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -4,6 +4,7 @@ import Avatar from '@mui/material/Avatar';
 interface HeaderProps {
   firstName: string;
   lastName: string;
+  title?: string | null;
 }
 
 // helper function to get initials from first and last name
@@ -11,10 +12,11 @@ const getInitials = (firstName: string, lastName: string): string => {
   return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
 };
 
-const Header: React.FC<HeaderProps> = ({ firstName, lastName }) => {
+const Header: React.FC<HeaderProps> = ({ firstName, lastName, title }) => {
   const initials = getInitials(firstName, lastName);
   const fullName = `${firstName} ${lastName}`;
-
+  // if title is provided, use it, otherwise use full name
+  const displayName = title ? title : fullName;
   return (
     <div className="w-full">
       <div className="flex items-center gap-4 px-6 py-4">
@@ -31,7 +33,7 @@ const Header: React.FC<HeaderProps> = ({ firstName, lastName }) => {
           {initials}
         </Avatar>
         {/* Custom Name */}
-        <h1 className="text-2xl font-medium text-gray-900">{fullName}</h1>
+        <h1 className="text-2xl font-medium text-gray-900">{displayName}</h1>
       </div>
 
       {/* Separator Line */}

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -4,7 +4,7 @@ import Avatar from '@mui/material/Avatar';
 interface HeaderProps {
   firstName: string;
   lastName: string;
-  title?: string | null;
+  title: string | null;
 }
 
 // helper function to get initials from first and last name

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -32,7 +32,7 @@ const Header: React.FC<HeaderProps> = ({ firstName, lastName, title }) => {
         >
           {initials}
         </Avatar>
-        {/* Custom Name */}
+        {/* Display Name */}
         <h1 className="text-2xl font-medium text-gray-900">{displayName}</h1>
       </div>
 

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import Avatar from '@mui/material/Avatar';
 
-interface CustomNameHeaderProps {
+interface HeaderProps {
   firstName: string;
   lastName: string;
 }
@@ -10,25 +11,25 @@ const getInitials = (firstName: string, lastName: string): string => {
   return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
 };
 
-const CustomNameHeader: React.FC<CustomNameHeaderProps> = ({
-  firstName,
-  lastName,
-}) => {
+const Header: React.FC<HeaderProps> = ({ firstName, lastName }) => {
   const initials = getInitials(firstName, lastName);
   const fullName = `${firstName} ${lastName}`;
 
   return (
     <div className="w-full">
-      {/* Header Section - no background, inherits from parent */}
       <div className="flex items-center gap-4 px-6 py-4">
-        {/* Custom Avatar with Initials */}
-        <div
-          className="w-10 h-10 rounded-full flex items-center justify-center"
-          style={{ backgroundColor: '#D0D0D0' }}
+        {/* Initials */}
+        <Avatar
+          sx={{
+            width: 40,
+            height: 40,
+            backgroundColor: '#D0D0D0',
+            fontSize: '0.875rem',
+            fontWeight: 500,
+          }}
         >
-          <span className="text-white text-sm font-medium">{initials}</span>
-        </div>
-
+          {initials}
+        </Avatar>
         {/* Custom Name */}
         <h1 className="text-2xl font-medium text-gray-900">{fullName}</h1>
       </div>
@@ -39,4 +40,4 @@ const CustomNameHeader: React.FC<CustomNameHeaderProps> = ({
   );
 };
 
-export default CustomNameHeader;
+export default Header;

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import Avatar from '@mui/material/Avatar';
+
+interface CustomNameHeaderProps {
+  initials?: string;
+  name?: string;
+}
+
+const CustomNameHeader: React.FC<CustomNameHeaderProps> = ({
+  initials = 'CN',
+  name = 'Custom Name',
+}) => {
+  return (
+    <div className="w-full">
+      <div className="flex items-center gap-4 px-6 py-4">
+        {/* MUI Avatar with Initials */}
+        <Avatar
+          sx={{
+            width: 40,
+            height: 40,
+            backgroundColor: '#D0D0D0',
+            fontSize: '0.875rem',
+            fontWeight: 500,
+          }}
+        >
+          {initials}
+        </Avatar>
+
+        {/* Name */}
+        <h1 className="text-2xl font-medium text-gray-900">{name}</h1>
+      </div>
+
+      {/* Separator Line */}
+      <div className="w-full h-px" style={{ backgroundColor: '#D9D9D9' }}></div>
+    </div>
+  );
+};
+
+export default CustomNameHeader;

--- a/package.json
+++ b/package.json
@@ -95,5 +95,6 @@
     "typescript": "^5.1.3",
     "vite": "^4.3.9",
     "vitest": "^0.32.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
### ℹ️ Issue

Closes #23 

### 📝 Description

Added a header component to display the user's name and initials, which takes in a required first name and last name.

### ✔️ Verification

Here's how it looks on the actual website:
<img width="1896" height="376" alt="Screenshot 2025-08-21 at 9 13 59 PM" src="https://github.com/user-attachments/assets/7e564feb-3ac3-4070-9d08-a433410f20f2" />