### PR TITLE
added route to get all labels

### DIFF
--- a/apps/backend/src/label/label.controller.spec.ts
+++ b/apps/backend/src/label/label.controller.spec.ts
@@ -26,6 +26,14 @@ export const mockLabel: Label = {
   tasks: [],
 };
 
+export const mockLabel2: Label = {
+  id: 2,
+  name: 'Test Label 2',
+  description: 'Test Description 2',
+  color: '#802b2bff',
+  tasks: [],
+};
+
 describe('LabelController', () => {
   let controller: LabelsController;
 
@@ -69,6 +77,16 @@ describe('LabelController', () => {
       const res = await controller.getAllLabels();
 
       expect(res).toEqual([mockLabel]);
+      expect(mockLabelService.getAllLabels).toHaveBeenCalled();
+    });
+    it('should return an array of labels with 2 labels', async () => {
+      jest
+        .spyOn(mockLabelService, 'getAllLabels')
+        .mockResolvedValue([mockLabel, mockLabel2]);
+
+      const res = await controller.getAllLabels();
+
+      expect(res).toEqual([mockLabel, mockLabel2]);
       expect(mockLabelService.getAllLabels).toHaveBeenCalled();
     });
   });

--- a/apps/backend/src/label/label.controller.spec.ts
+++ b/apps/backend/src/label/label.controller.spec.ts
@@ -9,6 +9,7 @@ export const mockLabelService: Partial<LabelsService> = {
   createLabel: jest.fn((labelDto: CreateLabelDTO) =>
     Promise.resolve(mockLabel),
   ),
+  getAllLabels: jest.fn(() => Promise.resolve([mockLabel])),
 };
 
 export const mockLabelDto: CreateLabelDTO = {
@@ -55,6 +56,20 @@ describe('LabelController', () => {
 
       expect(res).toEqual(mockLabel);
       expect(mockLabelService.createLabel).toHaveBeenCalledWith(mockLabelDto);
+    });
+  });
+
+  /* Test for retrieve all labels */
+  describe('GET /labels', () => {
+    it('should return an array of labels', async () => {
+      jest
+        .spyOn(mockLabelService, 'getAllLabels')
+        .mockResolvedValue([mockLabel]);
+
+      const res = await controller.getAllLabels();
+
+      expect(res).toEqual([mockLabel]);
+      expect(mockLabelService.getAllLabels).toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/label/label.controller.ts
+++ b/apps/backend/src/label/label.controller.ts
@@ -29,4 +29,12 @@ export class LabelsController {
   async createLabel(@Body() labelDto: CreateLabelDTO): Promise<Label> {
     return this.labelsService.createLabel(labelDto);
   }
+
+  /** Gets all labels.
+   * @returns An array of all labels.
+   */
+  @Get()
+  async getAllLabels(): Promise<Label[]> {
+    return this.labelsService.getAllLabels();
+  }
 }

--- a/apps/backend/src/label/label.service.spec.ts
+++ b/apps/backend/src/label/label.service.spec.ts
@@ -94,4 +94,15 @@ describe('LabelService', () => {
       );
     });
   });
+
+  describe('getAllLabels', () => {
+    it('should return an array of labels', async () => {
+      mockLabelsRepository.find.mockResolvedValue([mockLabel]);
+
+      const result = await service.getAllLabels();
+
+      expect(result).toEqual([mockLabel]);
+      expect(mockLabelsRepository.find).toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/backend/src/label/label.service.ts
+++ b/apps/backend/src/label/label.service.ts
@@ -31,4 +31,9 @@ export class LabelsService {
     const newLabel = this.labelRepository.create(labelDto);
     return this.labelRepository.save(newLabel);
   }
+
+  // Retrieves all labels
+  async getAllLabels(): Promise<Label[]> {
+    return this.labelRepository.find();
+  }
 }


### PR DESCRIPTION
### ℹ️ Issue

Closes no ticket

### 📝 Description

Added a route to get all labels. 

### ✔️ Verification

Unit testing and postman testing. 

<img width="1392" height="912" alt="Screenshot 2025-08-24 at 1 48 20 PM" src="https://github.com/user-attachments/assets/24a489c3-9b85-4027-a279-4ede3920d4ab" />


### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
