### PR TITLE
AA-49: Open Edit Task

### DIFF
--- a/apps/frontend/src/components/CreateEditTask.tsx
+++ b/apps/frontend/src/components/CreateEditTask.tsx
@@ -8,6 +8,7 @@ TODO: button functionality, add other components and states
 */
 interface CreateEditTaskProps {
   taskId?: number;
+  handleCancel: () => void;
 }
 
 const textFieldStyles = {
@@ -29,7 +30,10 @@ const baseButtonStyles = {
   position: 'absolute',
 };
 
-export const CreateEditTask: React.FC<CreateEditTaskProps> = ({ taskId }) => {
+export const CreateEditTask: React.FC<CreateEditTaskProps> = ({
+  taskId,
+  handleCancel,
+}) => {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
 
@@ -87,6 +91,7 @@ export const CreateEditTask: React.FC<CreateEditTaskProps> = ({ taskId }) => {
             right: '160px',
             color: 'black',
           }}
+          onClick={handleCancel}
         >
           Cancel
         </Button>

--- a/apps/frontend/src/components/TaskBoard.tsx
+++ b/apps/frontend/src/components/TaskBoard.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { TaskBox } from './TaskBox';
 import { Task, TaskCategory } from '../types/types';
 import apiClient from '@api/apiClient';
+import { CreateEditTask } from './CreateEditTask';
 
 interface TaskCategoryData {
   title: TaskCategory;
@@ -10,6 +11,7 @@ interface TaskCategoryData {
 
 export const TaskBoard: React.FC = () => {
   const [sortedTasks, setSortedTasks] = useState<TaskCategoryData[]>([]);
+  const [selectedTaskId, setSelectedTaskId] = useState<number | null>(null);
 
   function sortTasks(data: Task[]): TaskCategoryData[] {
     const Draft = { title: TaskCategory.DRAFT, tasks: [] as Task[] };
@@ -47,20 +49,38 @@ export const TaskBoard: React.FC = () => {
     }
   };
 
+  const openCreateEditTask = (taskId: number) => {
+    setSelectedTaskId(taskId);
+  };
+
+  const cancelCreateEditTask = () => {
+    setSelectedTaskId(null);
+  };
+
   useEffect(() => {
     fetchTasks();
   }, []);
 
   return (
     <div className="flex flex-row gap-4 p-4 items-start justify-center">
-      {sortedTasks.map((taskCategory, index) => (
-        <TaskBox
-          key={index}
-          title={taskCategory.title}
-          tasks={taskCategory.tasks}
-          onTaskDrop={fetchTasks}
-        />
-      ))}
+      {selectedTaskId ? (
+        <div className="w-full">
+          <CreateEditTask
+            taskId={selectedTaskId}
+            handleCancel={cancelCreateEditTask}
+          />
+        </div>
+      ) : (
+        sortedTasks.map((taskCategory, index) => (
+          <TaskBox
+            key={index}
+            title={taskCategory.title}
+            tasks={taskCategory.tasks}
+            onTaskDrop={fetchTasks}
+            handleClick={openCreateEditTask}
+          />
+        ))
+      )}
     </div>
   );
 };

--- a/apps/frontend/src/components/TaskBoard.tsx
+++ b/apps/frontend/src/components/TaskBoard.tsx
@@ -64,7 +64,7 @@ export const TaskBoard: React.FC = () => {
   return (
     <div className="flex flex-row gap-4 p-4 items-start justify-center">
       {selectedTaskId ? (
-        <div className="w-full">
+        <div className="w-full absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
           <CreateEditTask
             taskId={selectedTaskId}
             handleCancel={cancelCreateEditTask}

--- a/apps/frontend/src/components/TaskBox.tsx
+++ b/apps/frontend/src/components/TaskBox.tsx
@@ -7,12 +7,14 @@ interface TaskBoxProps {
   title: string;
   tasks?: Task[];
   onTaskDrop?: () => void;
+  handleClick: (taskId: number) => void;
 }
 
 export const TaskBox: React.FC<TaskBoxProps> = ({
   title,
   tasks,
   onTaskDrop,
+  handleClick,
 }) => {
   const handleDragStart = (
     e: React.DragEvent<HTMLDivElement>,
@@ -55,8 +57,10 @@ export const TaskBox: React.FC<TaskBoxProps> = ({
             tasks.map((task) => (
               <div
                 key={task.id}
+                className="hover:cursor-pointer"
                 draggable
                 onDragStart={(e) => handleDragStart(e, task, title)}
+                onClick={() => handleClick(task.id)}
               >
                 <TaskCard
                   colors={[]}


### PR DESCRIPTION
### ℹ️ Issue

Closes #49

### 📝 Description

I implemented functionality that allows a user to click on a task on the task board to open the interface for editing it. I also added in a function that closes the interface when the user clicks 'Cancel'.

Briefly list the changes made to the code:
1. Added an onClick handler to `TaskBox.tsx`
2. Added `selectedTaskId` state variable that is set to the task id needed to display the correct information in `CreateEditTask.tsx` and null when no task is selected
3. Added on onClick handler to the 'Cancel' button in `CreateEditTask.tsx`

### ✔️ Verification

I took a screen recording of this feature in action

https://github.com/user-attachments/assets/21adafc7-91c9-4a43-abba-e51ee1981dd9

### 🏕️ (Optional) Future Work / Notes

I assumed the saving functionality would be handled in #48, so I left it out of this branch to prevent any possible merge conflicts. I only focused on opening and closing the modal.
